### PR TITLE
Baked Textures are temporarily linked before export now!

### DIFF
--- a/blender/src/operators/texture_controller.py
+++ b/blender/src/operators/texture_controller.py
@@ -17,7 +17,7 @@ class GGT_OT_BAKE_TEXTURE_OT_GGT(bpy.types.Operator):
         bake_texture_path = tool.bake_texture_path
         bake_texture_name = tool.bake_texture_name
         texturePath = bpy.path.abspath(bake_texture_path)
-        fileName = os.path.join(texturePath, bake_texture_name + ".png")
+        fileName = os.path.join(texturePath, bake_texture_name + ".DIFFUSE.png")
         currentEngine = bpy.context.scene.render.engine
         activeObj = bpy.context.view_layer.objects.active
         # Validate Mesh With Material Is Selected
@@ -56,7 +56,7 @@ class GGT_OT_CREATE_BAKE_TEXTURES_OT_GGT(Operator):
         scene = context.scene
         tool = scene.godot_game_tools
         textureSize = tool.bake_texture_size
-        bake_texture_name = tool.bake_texture_name
+        bake_texture_name = tool.bake_texture_name + ".DIFFUSE"
         activeObj = bpy.context.view_layer.objects.active
         mesh = None
         if activeObj is not None:
@@ -98,7 +98,7 @@ class GGT_OT_SAVE_BAKE_TEXTURES_OT_GGT(Operator):
         scene = context.scene
         tool = scene.godot_game_tools
         bake_texture_path = tool.bake_texture_path
-        bake_texture_name = tool.bake_texture_name
+        bake_texture_name = tool.bake_texture_name + ".DIFFUSE"
         texturePath = bpy.path.abspath(bake_texture_path)
         activeObj = bpy.context.view_layer.objects.active
         if len(activeObj.material_slots) > 0:


### PR DESCRIPTION
Now, when you have a procedural texture, and you bake the texture using the Godot_Game_Tools buttons, the texture nodes get hooked up and are exported with the model! The node links are restored immediately after export. 

Note, the .zip plugin file was NOT modified by this update.